### PR TITLE
Allow running in vanilla session

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -7,7 +7,7 @@ check_proc <- function(pkgdir, pkgname, version = c("old", "new")) {
   dir <- dir_find(pkgdir, "check", pkgname)
   tarball <- with_envvar(
     c(CRANCACHE_REPOS = "cran,bioc", CRANCACHE_QUIET = "yes"),
-    crancache::download_packages(pkgname, dir, repos = get_repos(bioc = TRUE))[,2]
+    crancache::download_packages(pkgname, dir, repos = get_repos(bioc = TRUE), quiet = TRUE)[,2]
   )
 
   out <- file.path(dir, version)

--- a/R/check.R
+++ b/R/check.R
@@ -7,7 +7,7 @@ check_proc <- function(pkgdir, pkgname, version = c("old", "new")) {
   dir <- dir_find(pkgdir, "check", pkgname)
   tarball <- with_envvar(
     c(CRANCACHE_REPOS = "cran,bioc", CRANCACHE_QUIET = "yes"),
-    crancache::download_packages(pkgname, dir)[,2]
+    crancache::download_packages(pkgname, dir, repos = get_repos(bioc = TRUE))[,2]
   )
 
   out <- file.path(dir, version)

--- a/R/deps-install.R
+++ b/R/deps-install.R
@@ -136,9 +136,3 @@ deps_install_done <- function(state, worker) {
 
   state
 }
-
-deps_install <- function(pkgdir, pkgname, quiet = FALSE, new_session = FALSE) {
-  px_opts <- deps_install_opts(pkgdir, pkgname, quiet = FALSE)
-  execute_r(px_opts, new_session = new_session)
-}
-

--- a/R/deps.R
+++ b/R/deps.R
@@ -4,13 +4,7 @@
 
 cran_revdeps <- function(package, dependencies, bioc) {
   stopifnot(is_string(package))
-  repos <- c(
-    if (bioc) bioc_install_repos(),
-    getOption("repos")
-  )
-  if (! "CRAN" %in% names(repos) || repos["CRAN"] == "@CRAN@") {
-    repos["CRAN"] <- "https://cloud.r-project.org"
-  }
+  repos <- get_repos(bioc)
 
   allpkgs <- available_packages(repos = repos)
   alldeps <- allpkgs[, dependencies, drop = FALSE]
@@ -19,6 +13,16 @@ cran_revdeps <- function(package, dependencies, bioc) {
   rd <- grepl(paste0("\\b", package, "\\b"), deps)
 
   allpkgs[rd, "Package"]
+}
+
+get_repos <- function(bioc) {
+  repos <- c(
+    if (bioc) bioc_install_repos(),
+    getOption("repos")
+  )
+  if (! "CRAN" %in% names(repos) || repos["CRAN"] == "@CRAN@") {
+    repos["CRAN"] <- "https://cloud.r-project.org"
+  }
 }
 
 cran_deps <- function(package, repos) {

--- a/R/download.R
+++ b/R/download.R
@@ -2,7 +2,7 @@ download_opts <- function(pkgdir, pkgname) {
   dir <- dir_find(pkgdir, "check", pkgname)
 
   func <- function(pkgname, dir) {
-    crancache::download_packages(pkgname, dir)[,2]
+    crancache::download_packages(pkgname, dir, repos = get_repos(bioc = TRUE))[,2]
   }
 
   r_process_options(

--- a/R/revdepcheck.R
+++ b/R/revdepcheck.R
@@ -106,7 +106,7 @@ revdep_install <- function(pkg = ".", quiet = FALSE) {
       dir_find(pkg, "old"),
       with_options(
         list(warn = 2),
-        install_packages(pkgname, quiet = quiet)
+        install_packages(pkgname, quiet = quiet, repos = get_repos(bioc = TRUE))
       )
     )
   )


### PR DESCRIPTION
by always specifying `repos` explicitly.

Also closes #37.