### PR TITLE
Various minor fixes for reporting

### DIFF
--- a/R/report.R
+++ b/R/report.R
@@ -180,6 +180,7 @@ report_revdeps <- function(pkg = ".") {
 
   probs <- map_lgl(packages, problems)
   pkgname <- map_chr(packages, function(x) x$new$package %||% NA_character_)
+  pkgname[is.na(pkgname)] <- names(packages)[is.na(pkgname)]
 
   data.frame(
     problems = probs,

--- a/R/report.R
+++ b/R/report.R
@@ -62,6 +62,8 @@ revdep_report_problems <- function(pkg = ".", file = "") {
 }
 
 failure_details <- function(x, file = "") {
+  if (inherits(x, "rcmdcheck_error")) return(failure_details_error(x, file))
+
   old <- x$old[[1]]
   cat_header(old$package, file = file)
   cat_line("Version: ", old$version, file = file)
@@ -118,6 +120,24 @@ format_details_bullet <- function(x, max_lines = 20) {
     paste0(pad, details, "\n", collapse = ""),
     "\n"
   )
+}
+
+failure_details_error <- function(x, file) {
+  cat_header(x$package, file = file)
+
+  cat_header(level = 2, "Old stdout", file = file)
+  cat(x$old$stdout, sep = "\n", file = file)
+
+  cat_header(level = 2, "Old stderr", file = file)
+  cat(x$old$stderr, sep = "\n", file = file)
+
+  cat_header(level = 2, "New stdout", file = file)
+  cat(x$new$stdout, sep = "\n", file = file)
+
+  cat_header(level = 2, "New stderr", file = file)
+  cat(x$new$stderr, sep = "\n", file = file)
+
+  invisible()
 }
 
 

--- a/R/report.R
+++ b/R/report.R
@@ -179,12 +179,12 @@ report_revdeps <- function(pkg = ".") {
   }
 
   probs <- map_lgl(packages, problems)
-  pkgname <- map_chr(packages, function(x) x$new$package)
+  pkgname <- map_chr(packages, function(x) x$new$package %||% NA_character_)
 
   data.frame(
     problems = probs,
     package = ifelse(probs, problem_link(pkgname), pkgname),
-    version = map_chr(packages, function(x) x$new$version),
+    version = map_chr(packages, function(x) x$new$version %||% NA_character_),
     error = map_chr(packages, make_summary, "error"),
     warning = map_chr(packages, make_summary, "warning"),
     note = map_chr(packages, make_summary, "note"),

--- a/R/results.R
+++ b/R/results.R
@@ -26,6 +26,8 @@ revdep_todo <- function(pkg = ".") {
 }
 
 is_broken <- function(x) {
+  if (inherits(x, "rcmdcheck_error")) return(TRUE)
+
   # TODO: use better code from rcmdcheck
   n_broken_type <- function(x, type) {
     recs <- x$cmp[x$cmp$type == type, , drop = FALSE]

--- a/R/revdepcheck.R
+++ b/R/revdepcheck.R
@@ -261,13 +261,13 @@ revdep_add_broken <- function(pkg = ".") {
   packages <- revdep_results(pkg, db_list(pkg))
   broken <- vapply(packages, is_broken, integer(1))
 
-  to_add <- db_list(pkg)[broken]
+  to_add <- db_list(pkg)[broken != 0L]
   if (length(to_add) == 0) {
-    message("No broken packages to re-test")
+    message("No broken packages to re-check")
   } else {
     message(
-      "Re-checking broken packages: ",
-      str_trunc(paste(to_add, collapse = ","), 100)
+      "Re-checking ", length(to_add), " broken packages: ",
+      str_trunc(paste(to_add, collapse = ", "), 100)
     )
     revdep_add(pkg, to_add)
 


### PR DESCRIPTION
"Hammer style", because I wasn't sure about the code design. I think we could use a new class that wraps both `"rcmdcheck_comparison"` and allows capturing errors, timeouts etc. if we don't compare.

- Packages where the internal results are of class `"rcmdcheck_error"` are considered broken, for reporting the stdout and stderr for old and new are printed.
- These packages show with version = NA in the list, I'm sure we can do better here.
- Fixed adding broken packages.