### PR TITLE
Cleanup immediately after parsing check result

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -121,6 +121,8 @@ check_done <- function(state, worker) {
     )
   }
 
+  cleanup_chkres(state, worker, iam_old)
+
   status <- if (isTRUE(worker$killed)) {
     "TIMEOUT"
   } else if (!inherits(chkres, "rcmdcheck")) {

--- a/R/cleanup.R
+++ b/R/cleanup.R
@@ -16,7 +16,6 @@ cleanup_chkres <- function(state, worker, iam_old) {
   check_dir <- dir_find(pkgdir, "check", package)
   rcheck <- file.path(
     check_dir,
-    package,
     if (iam_old) "old" else "new",
     paste0(package, ".Rcheck")
   )

--- a/R/cleanup.R
+++ b/R/cleanup.R
@@ -7,3 +7,20 @@ cleanup_library <- function(state, worker) {
   libdir <- dir_find(pkgdir, "pkg", package)
   unlink(libdir, recursive = TRUE)
 }
+
+cleanup_chkres <- function(state, worker, iam_old) {
+  pkgdir <- state$options$pkgdir
+  package <- worker$package
+
+  # Delete all sources/binaries cached by R CMD check
+  check_dir <- dir_find(pkgdir, "check", package)
+  rcheck <- file.path(
+    check_dir,
+    package,
+    if (iam_old) "old" else "new",
+    paste0(package, ".Rcheck")
+  )
+
+  unlink(file.path(rcheck, "00_pkg_src"), recursive = TRUE)
+  unlink(file.path(rcheck, package), recursive = TRUE)
+}


### PR DESCRIPTION
Code adapted from `revdep_clean()`, maybe we could extract common parts into a separate function?

Related to https://github.com/r-lib/revdepcheck/issues/47#issuecomment-317554763.