### PR TITLE
Add status field

### DIFF
--- a/R/compare.R
+++ b/R/compare.R
@@ -13,6 +13,7 @@ rcmdcheck_error <- function(package, old, new) {
   structure(
     list(
       package = package,
+      status = "E",
       old = old,
       new = new
     ),


### PR DESCRIPTION
needed for `revdep_report_cran()` if packages failed to check. Not sure about the best value here.