### PR TITLE
Require processx >= 3.0.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Imports:
     gmailr,
     knitr,
     prettyunits,
-    processx,
+    processx (>= 3.0.1),
     progress,
     rcmdcheck (>= 1.2.1.9003),
     remotes (>= 1.0.0.9000),


### PR DESCRIPTION
Closes #129

revdepcheck assumes existence of the `read_output()` and `read_error()` process methods which are only present in recent versions.