### PR TITLE
Use new tibble data structures

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -160,7 +160,8 @@ check_done <- function(state, worker) {
   if (new_state == "done") {
     clear_line()
 
-    comparison <- db_results(state$options$pkgdir, worker$package)[[1]]
+    results <- db_results(state$options$pkgdir, worker$package)
+    comparison <- results$comparisons[[1]]
     print(summary(comparison))
 
     state$progress_bar$tick(tokens = list(packages = checking_now(state)))

--- a/R/event-loop.R
+++ b/R/event-loop.R
@@ -46,9 +46,13 @@ run_event_loop <- function(state) {
 
   ## Our global progress bar
   state$progress_bar <- progress_bar$new(
-    total = nrow(state$packages),
+    total = state$total,
     format = "[:current/:total] :elapsedfull | ETA: :eta | :packages"
   )
+
+  if (!is_null(state$elapsed)) {
+    state$progress_bar$tick(state$elapsed)
+  }
 
   # Initialise one task for each worker
   for (i in seq_len(state$options$num_workers)) {

--- a/R/results.R
+++ b/R/results.R
@@ -11,9 +11,11 @@
 
 revdep_details <- function(pkg = ".", revdep) {
   assert_that(is_string(revdep))
+  results <- db_results(pkg, revdep)
+  comparison <- results$comparison[[1]]
 
   structure(
-    db_results(pkg, revdep)[[1]],
+    comparison,
     class = "revdepcheck_details"
   )
 }
@@ -29,8 +31,9 @@ print.revdepcheck_results <- function(x, ...) {
 #' @rdname revdep_details
 
 revdep_summary <- function(pkg = ".") {
+  comparisons <- db_results(pkg)$comparisons
   structure(
-    db_results(pkg, NULL),
+    comparisons,
     class = "revdepcheck_results"
   )
 }

--- a/R/todo.R
+++ b/R/todo.R
@@ -27,8 +27,8 @@ revdep_add <- function(pkg = ".", packages) {
 revdep_add_broken <- function(pkg = ".") {
   pkg <- pkg_check(pkg)
 
-  packages <- db_results(pkg, NULL)
-  broken <- map_lgl(packages, is_broken)
+  comparisons <- db_results(pkg)$comparisons
+  broken <- map_lgl(comparisons, is_broken)
 
   to_add <- names(broken[broken])
   if (length(to_add) == 0) {


### PR DESCRIPTION
Includes #165 

* Change internals to use new tibble data structures.

* Revdep checks now loop over groups. This is helpful when you're checking the revdeps of several packages since you're likely less interested in your higher order revdeps than your direct revdeps, and you can interrupt the checking process if you judge the checks for extra packages are good enough.

  Since `pkgs_revdeps()` (upcoming function) always groups TODO packages by repository, this means that the CRAN and Bioconductor packages are checked separately.
