### PR TITLE
Handle groups in revdep_report_cran()

### DIFF
--- a/man/revdep_report_summary.Rd
+++ b/man/revdep_report_summary.Rd
@@ -11,7 +11,7 @@ revdep_report_summary(pkg = ".", file = "")
 
 revdep_report_problems(pkg = ".", file = "")
 
-revdep_report_cran(pkg = ".")
+revdep_report_cran(pkg = ".", groups = NULL)
 
 revdep_report(pkg = ".")
 }
@@ -19,6 +19,10 @@ revdep_report(pkg = ".")
 \item{pkg}{Path to package.}
 
 \item{file}{File to write output to. Default will write to console.}
+
+\item{groups}{A named character vector to specify group levels to
+summarise in. The name indexes a group and the value indexes a
+level.}
 }
 \description{
 You can use these functions to get intermediate reports of a \code{\link[=revdep_check]{revdep_check()}}


### PR DESCRIPTION
Includes #167 

- Use the `repo` column to determine CRAN packages
- Indicate to user what groups (other than `repo`) the summary aggregates over
- Add `groups` argument to specify levels to summarise in

Example:

  ```
  revdep_report_cran(path)
  #> The summary aggregates over the following groups:
  #>
  #> # A tibble: 2 x 1
  #>   set
  #>   <chr>
  #> 1 rlang
  #> 2 purrr
  #>
  #> Pass `groups` to specify group levels to summarise in.
  #>
  #> ## revdepcheck results
  #>
  #> We checked 6 reverse dependencies (4 from CRAN + 2 from
  #> BioConductor), comparing R CMD check results across CRAN and dev
  #> versions of this package.
  #>
  #>  * We saw 0 new problems
  #>  * We failed to check 3 packages
  #>
  #> Issues with CRAN packages are summarised below.
  #>
  #> ### Failed to check
  #>
  #> * AMR        (failed to install)
  #> * amt        (failed to install)
  #> * adaptalint (failed to install)
  ```

Then, to summarise within a specific set:

  ```
  revdep_report_cran(path, c(set = "rlang"))
  #> ## revdepcheck results
  #>
  #> We checked 2 reverse dependencies, comparing R CMD check results
  #> across CRAN and dev versions of this package.
  #>
  #>  * We saw 0 new problems
  #>  * We failed to check 2 packages
  #>
  #> Issues with CRAN packages are summarised below.
  #>
  #> ### Failed to check
  #>
  #> * AMR (failed to install)
  #> * mt (failed to install)
  ```
