### PR TITLE
Update email.R

### DIFF
--- a/R/email.R
+++ b/R/email.R
@@ -215,6 +215,7 @@ email_data_defaults <- function(pkg = ".") {
     release_date = red("--release_date--"),
     rel_release_date = red("--rel_release_date---"),
     release_version = red("--release_version--"),
+    release_details = red("--release_details--"),
 
     your_package = green("your_package"),
     your_version = green("your_version"),


### PR DESCRIPTION
The email template needs the `release_version` variable and `usethis::use_revdep()` does not set it up. 

Related to : https://github.com/r-lib/usethis/pull/559