### PR TITLE
use `force=TRUE` during revdep_install

### DIFF
--- a/R/revdepcheck.R
+++ b/R/revdepcheck.R
@@ -149,7 +149,7 @@ revdep_install <- function(pkg = ".", quiet = FALSE) {
       dir_find(pkg, "new"),
       rlang::with_options(
         warn = 2,
-        install_local(pkg, quiet = quiet, repos = get_repos(bioc = TRUE))
+        install_local(pkg, quiet = quiet, repos = get_repos(bioc = TRUE), force = TRUE)
       )
     )
   )


### PR DESCRIPTION
now that I'm thinking more about it, the issue might come from somewhere else  (maybe `with_libpaths()`)... but in my case, `install_packages()` would not install the "new" version of the package because it detected that the `SHA1` hadn't changed, leaving `revdep/library/{pkg}/new/{pkg}` empty.

The checks continued with the final result making it seem that all tests failed (actually due to the absence of the "new" version of the package in the library). Would adding checks to ensure that both the `new` and the `old` libraries are not empty be pertinent as well?