### PR TITLE
WIP: Allow only one installation process at any time

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,6 +42,7 @@ Suggests:
     testthat
 Remotes:
     r-lib/crancache,
+    r-lib/crayon,
     r-lib/rcmdcheck
 Encoding: UTF-8
 LazyData: true

--- a/R/deps-install.R
+++ b/R/deps-install.R
@@ -3,7 +3,7 @@
 #' @importFrom crancache available_packages
 #' @importFrom withr with_envvar
 
-deps_install_opts <- function(pkgdir, pkgname, quiet = FALSE, env = character()) {
+deps_install_opts <- function(pkgdir, pkgname, num_workers, quiet = FALSE, env = character()) {
   func <- function(libdir, packages, quiet, repos) {
     ip <- crancache::install_packages
     withr::with_libpaths(
@@ -13,7 +13,8 @@ deps_install_opts <- function(pkgdir, pkgname, quiet = FALSE, env = character())
         dependencies = FALSE,
         lib = libdir[1],
         quiet = quiet,
-        repos = repos
+        repos = repos,
+        Ncpus = num_workers
       )
     )
   }
@@ -82,8 +83,8 @@ deps_install_task <- function(state, task) {
 
 
   "!DEBUG Install dependencies for package `pkgname`"
-  px_opts <- deps_install_opts(pkgdir, pkgname, quiet = state$options$quiet,
-                               env = state$options$env)
+  px_opts <- deps_install_opts(pkgdir, pkgname, num_workers = state$options$num_workers,
+                               quiet = state$options$quiet, env = state$options$env)
   px <- r_process$new(px_opts)
 
   ## Update state

--- a/R/deps-install.R
+++ b/R/deps-install.R
@@ -14,8 +14,7 @@ deps_install_opts <- function(pkgdir, pkgname, num_workers, quiet = FALSE, env =
           dependencies = FALSE,
           lib = libdir[1],
           quiet = quiet,
-          repos = repos,
-          Ncpus = num_workers
+          repos = repos
         )
         stopifnot(all(packages %in% installed.packages(libdir[1])))
       }

--- a/R/deps-install.R
+++ b/R/deps-install.R
@@ -8,14 +8,17 @@ deps_install_opts <- function(pkgdir, pkgname, num_workers, quiet = FALSE, env =
     ip <- crancache::install_packages
     withr::with_libpaths(
       libdir,
-      ip(
-        packages,
-        dependencies = FALSE,
-        lib = libdir[1],
-        quiet = quiet,
-        repos = repos,
-        Ncpus = num_workers
-      )
+      {
+        ip(
+          packages,
+          dependencies = FALSE,
+          lib = libdir[1],
+          quiet = quiet,
+          repos = repos,
+          Ncpus = num_workers
+        )
+        stopifnot(all(packages %in% installed.packages(libdir[1])))
+      }
     )
   }
 

--- a/R/deps-install.R
+++ b/R/deps-install.R
@@ -16,7 +16,7 @@ deps_install_opts <- function(pkgdir, pkgname, num_workers, quiet = FALSE, env =
           quiet = quiet,
           repos = repos
         )
-        stopifnot(all(packages %in% installed.packages(libdir[1])))
+        stopifnot(all(packages %in% rownames(installed.packages(libdir[1]))))
       }
     )
   }

--- a/R/deps.R
+++ b/R/deps.R
@@ -1,7 +1,7 @@
 
 cran_revdeps <- function(package, dependencies = TRUE, bioc = FALSE) {
   pkgs <- cran_revdeps_versions(package, dependencies, bioc)$package
-  pkgs[order(get_n_deps(pkgs$package, bioc))]
+  pkgs[order(get_n_deps(pkgs, bioc))]
 }
 
 #' @importFrom remotes bioc_install_repos

--- a/R/deps.R
+++ b/R/deps.R
@@ -1,7 +1,7 @@
 
 cran_revdeps <- function(package, dependencies = TRUE, bioc = FALSE) {
   pkgs <- cran_revdeps_versions(package, dependencies, bioc)$package
-  pkgs[order(get_n_deps(pkgs$package))]
+  pkgs[order(get_n_deps(pkgs$package, bioc))]
 }
 
 #' @importFrom remotes bioc_install_repos
@@ -72,7 +72,8 @@ parse_deps <- function(deps) {
   res
 }
 
-get_n_deps <- function(pkgs) {
+get_n_deps <- function(pkgs, bioc) {
+  repos <- get_repos(bioc)
   allpkgs <- available_packages(repos = repos)
   first_deps <- tools::package_dependencies(pkgs, allpkgs)
   map_int(first_deps, get_n_strong_deps, allpkgs)

--- a/R/deps.R
+++ b/R/deps.R
@@ -75,7 +75,10 @@ parse_deps <- function(deps) {
 get_n_deps <- function(pkgs, bioc) {
   repos <- get_repos(bioc)
   allpkgs <- available_packages(repos = repos)
-  first_deps <- tools::package_dependencies(pkgs, allpkgs)
+  first_deps <- tools::package_dependencies(
+    pkgs, allpkgs,
+    which = c("Depends", "Imports", "LinkingTo", "Suggests")
+  )
   map_int(first_deps, get_n_strong_deps, allpkgs)
 }
 

--- a/R/deps.R
+++ b/R/deps.R
@@ -81,5 +81,5 @@ get_n_deps <- function(pkgs, bioc) {
 
 get_n_strong_deps <- function(pkgs, allpkgs) {
   recursive_deps <- tools::package_dependencies(pkgs, allpkgs)
-  length(unique(c(pkgs, unlist(all_deps))))
+  length(unique(c(pkgs, unlist(recursive_deps))))
 }

--- a/R/deps.R
+++ b/R/deps.R
@@ -1,7 +1,7 @@
 
 cran_revdeps <- function(package, dependencies = TRUE, bioc = FALSE) {
   pkgs <- cran_revdeps_versions(package, dependencies, bioc)$package
-  pkgs[order(tolower(pkgs))]
+  pkgs[order(get_n_deps(pkgs$package))]
 }
 
 #' @importFrom remotes bioc_install_repos
@@ -70,4 +70,15 @@ parse_deps <- function(deps) {
 
   res[notempty] <- deps
   res
+}
+
+get_n_deps <- function(pkgs) {
+  allpkgs <- available_packages(repos = repos)
+  first_deps <- tools::package_dependencies(pkgs, allpkgs)
+  map_int(first_deps, get_n_strong_deps, allpkgs)
+}
+
+get_n_strong_deps <- function(pkgs, allpkgs) {
+  recursive_deps <- tools::package_dependencies(pkgs, allpkgs)
+  length(unique(c(pkgs, unlist(all_deps))))
 }

--- a/R/event-loop.R
+++ b/R/event-loop.R
@@ -223,6 +223,17 @@ schedule_next_task <- function(state) {
     return(task("idle"))
   }
 
+  ## install whenever a worker is ready
+  ## todo -> deps_installing
+  ## Only if no packages left to install
+  ready <- state$packages$state == "todo"
+  installing <- state$packages$state == "deps_installing"
+  if (any(ready) && !any(installing)) {
+    pkg <- state$packages$package[ready][1]
+    "!DEBUG schedule dependency installs for `pkg`"
+    return(task("deps_install", pkg))
+  }
+
   ## done-downloaded -> done-checking
   ready <- state$packages$state == "done-downloaded"
   if (any(ready)) {
@@ -252,16 +263,6 @@ schedule_next_task <- function(state) {
     pkg <- state$packages$package[ready][1]
     "!DEBUG schedule downloading `pkg` with the old version"
     return(task("download", pkg, 1L))
-  }
-
-  ## todo -> deps_installing
-  ## Only if no packages left to install
-  ready <- state$packages$state == "todo"
-  installing <- state$packages$state == "deps_installing"
-  if (any(ready) && !any(installing)) {
-    pkg <- state$packages$package[ready][1]
-    "!DEBUG schedule dependency installs for `pkg`"
-    return(task("deps_install", pkg))
   }
 
   task("idle")

--- a/R/event-loop.R
+++ b/R/event-loop.R
@@ -255,8 +255,10 @@ schedule_next_task <- function(state) {
   }
 
   ## todo -> deps_installing
+  ## Only if no packages left to install
   ready <- state$packages$state == "todo"
-  if (any(ready)) {
+  installing <- state$packages$state == "deps_installing"
+  if (any(ready) && !any(installing)) {
     pkg <- state$packages$package[ready][1]
     "!DEBUG schedule dependency installs for `pkg`"
     return(task("deps_install", pkg))

--- a/R/revdepcheck.R
+++ b/R/revdepcheck.R
@@ -71,7 +71,7 @@ revdep_check <- function(pkg = ".",
     stage <- db_metadata_get(pkg, "todo") %|0|% "init"
     switch(stage,
       init =    revdep_init(pkg, dependencies = dependencies, bioc = bioc),
-      install = revdep_install(pkg, quiet = quiet, env = env),
+      install = revdep_install(pkg, num_workers = num_workers, quiet = quiet, env = env),
       run =     revdep_run(pkg, quiet = quiet, timeout = timeout,
                            num_workers = num_workers, env = env),
       report =  revdep_final_report(pkg),
@@ -121,7 +121,7 @@ revdep_init <- function(pkg = ".",
   invisible()
 }
 
-revdep_install <- function(pkg = ".", quiet = FALSE, env = character()) {
+revdep_install <- function(pkg = ".", num_workers = 1, quiet = FALSE, env = character()) {
   pkg <- pkg_check(pkg)
   pkgname <- pkg_name(pkg)
 
@@ -143,7 +143,7 @@ revdep_install <- function(pkg = ".", quiet = FALSE, env = character()) {
       dir_find(pkg, "old"),
       rlang::with_options(
         warn = 2,
-        install_packages(pkgname, quiet = quiet, repos = get_repos(bioc = TRUE), upgrade = "always")
+        install_packages(pkgname, quiet = quiet, repos = get_repos(bioc = TRUE), upgrade = "always", Ncpus = num_workers)
       )
     )
   )
@@ -157,7 +157,7 @@ revdep_install <- function(pkg = ".", quiet = FALSE, env = character()) {
       dir_find(pkg, "new"),
       rlang::with_options(
         warn = 2,
-        install_local(pkg, quiet = quiet, repos = get_repos(bioc = TRUE), force = TRUE, upgrade = "always")
+        install_local(pkg, quiet = quiet, repos = get_repos(bioc = TRUE), force = TRUE, upgrade = "always", Ncpus = num_workers)
       )
     )
   )


### PR DESCRIPTION
and check packages in increasing order of number of dependencies.

This gives much much better results on Linux: the CPU is fully utilized almost from the start, even on systems with limited I/O such as on Azure. Even on other systems, first results are achieved faster, because less work needs to be done initially.