### PR TITLE
More resilient reporting when revdep's DESCRIPTION is missing or empty

### DIFF
--- a/R/cloud.R
+++ b/R/cloud.R
@@ -311,7 +311,11 @@ cloud_check_result <- function(check_log, description, dependency_error) {
         notes = NA_character_,
 
         description = description$str(normalize = FALSE),
-        package     = description$get("Package"),
+        # DESCRIPTION can exist but be empty, e.g. for a Bioconductor package
+        # or a when package's minimum R version isn't met
+        # at the VERY LEAST, let's get a package name
+        package     = description$get("Package") %|%
+                        sub("[.]Rcheck", "", basename(check_dir)),
         version     = description$get("Version")[[1]],
         cran        = description$get_field("Repository", "") == "CRAN",
         bioc        = description$has_fields("biocViews"),
@@ -382,7 +386,10 @@ cloud_compare <- function(pkg) {
   old <- cloud_check_result(old, description, dependency_error)
   new <- cloud_check_result(new, description, dependency_error)
   if (isTRUE(dependency_error)) {
-    res <- rcmdcheck_error(description$get("Package"), old, new)
+    # DESCRIPTION can exist but be empty, e.g. for a Bioconductor package
+    # or a when package's minimum R version isn't met
+    # at the VERY LEAST, let's get a package name
+    res <- rcmdcheck_error(description$get("Package") %|% basename(pkg), old, new)
     res$version <- description$get("Version")[[1]]
     return(res)
   }

--- a/R/cloud.R
+++ b/R/cloud.R
@@ -369,6 +369,9 @@ cloud_check_result <- function(check_log, description, dependency_error) {
 
 cloud_compare <- function(pkg) {
   desc_path <- file.path(pkg, "DESCRIPTION")
+  if (!file.exists(desc_path)) {
+    return(rcmdcheck_error(basename(pkg), old = NULL, new = NULL))
+  }
   description <- desc::desc(file = desc_path)
 
   old <- file.path(pkg, "old", paste0(basename(pkg), ".Rcheck"), "00check.log")

--- a/R/cloud.R
+++ b/R/cloud.R
@@ -314,8 +314,7 @@ cloud_check_result <- function(check_log, description, dependency_error) {
         # DESCRIPTION can exist but be empty, e.g. for a Bioconductor package
         # or a when package's minimum R version isn't met
         # at the VERY LEAST, let's get a package name
-        package     = description$get("Package") %|%
-                        sub("[.]Rcheck", "", basename(check_dir)),
+        package     = description$get_field("Package", sub("[.]Rcheck$", "", basename(check_dir))),
         version     = description$get("Version")[[1]],
         cran        = description$get_field("Repository", "") == "CRAN",
         bioc        = description$has_fields("biocViews"),
@@ -389,7 +388,7 @@ cloud_compare <- function(pkg) {
     # DESCRIPTION can exist but be empty, e.g. for a Bioconductor package
     # or a when package's minimum R version isn't met
     # at the VERY LEAST, let's get a package name
-    res <- rcmdcheck_error(description$get("Package") %|% basename(pkg), old, new)
+    res <- rcmdcheck_error(description$get_field("Package", basename(pkg)), old, new)
     res$version <- description$get("Version")[[1]]
     return(res)
   }


### PR DESCRIPTION
Fixes #295, fixes #310

I had a very conservative goal here: replace the `NA`s we see for problem packages in `cloud_summary()`, `revdep/README.md` and `revdep/failures.md` with a package name. I have succeeded in this.

There are still quite a few problems with how these problem packages are being reported (or, rather, are not necessarily being reported), but I think other issues already capture some of the more substantive problems (such as #317, #301). 

I was developing against a specific cloud revdep run for usethis, so I had authentic weird stuff to work with. All the `NA`s in my case were due to `DESCRIPTION` being non-existent or empty, for a revdep package. That was explained by the package being on Bioconductor, not CRAN, or requiring a higher R version than we were checking with. Or because shit happens? There was at least one package that had bizarre results for no identifiable reason and this self-resolved in a future revdep run.