### PR TITLE
Try untar-listing to check if the format is valid

### DIFF
--- a/R/cloud.R
+++ b/R/cloud.R
@@ -150,7 +150,13 @@ cloud_fetch_results <- function(job_name = cloud_job(pkg = pkg), pkg = ".") {
   pb2 <- cli_progress_bar(format = "Extracting package results: {pb_percent}", total = sum(to_extract))
   for (i in which(to_extract)) {
     out_file <- out_files[[i]]
-    utils::untar(out_file, exdir = out_dir)
+    files <- suppressWarnings(utils::untar(out_file, exdir = out_dir, list = TRUE))
+    if (length(files) == 0) {
+      # Retry downloading next time
+      unlink(out_file)
+    } else {
+      utils::untar(out_file, exdir = out_dir)
+    }
     cli_progress_update(id = pb2)
   }
   cli_progress_done(id = pb2)


### PR DESCRIPTION
I have seen several instances of malformed `.tar.gz` files (uncompressed JSON contents), these files were downloaded correctly after they were deleted manually. Is there a better way to check sanity of a `.tar.gz` file?