### PR TITLE
Add cran parameter (#333 and #340 candidate fix)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: revdepcheck
 Title: Automated Reverse Dependency Checking
-Version: 1.0.0.9001
+Version: 1.0.0.9002
 Authors@R: c(
     person("Gábor", "Csárdi", , "csardi.gabor@gmail.com", c("cre", "aut", "cph")),
     person("Hadley", "Wickham", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,6 +57,7 @@ VignetteBuilder:
 Remotes:
     r-lib/crancache,
     r-lib/remotes
+Config/Needs/website: tidyverse/tidytemplate
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,4 +59,4 @@ Remotes:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,7 +55,7 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes:
-    r-lib/crancache
+    git::https://github.com/r-lib/crancache.git@main,
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,4 +61,4 @@ Config/Needs/website: tidyverse/tidytemplate
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# 1.0.0.9002
+
+* Add `cran` parameter to the `get_repos()` internal and propagate it to the
+  upstream functions including `revdep_check()`. It allow user to decide
+  whether htey want to always append CRAN mirror to repos or not (@maksymis)
+
 # 1.0.0.9000
 
 * `cloud_results()` gains a progress bar so you can see what's happening

--- a/R/deps-install.R
+++ b/R/deps-install.R
@@ -48,7 +48,7 @@ deps_install_opts <- function(pkgdir, pkgname, quiet = FALSE, env = character())
 deps_opts <- function(pkgname, exclude = character()) {
   ## We set repos, so that dependencies from Bioconductor are installed
   ## automatically
-  repos <- get_repos(bioc = TRUE)
+  repos <- get_repos(bioc = TRUE, cran = TRUE)
 
   ## We have to do this "manually", because some of the dependencies
   ## might be also dependencies of crancache, so they will be already

--- a/R/deps.R
+++ b/R/deps.R
@@ -4,17 +4,17 @@
 #' @param package The package to search for reverse dependencies
 #' @inheritParams revdep_check
 #' @export
-cran_revdeps <- function(package, dependencies = TRUE, bioc = FALSE) {
-  pkgs <- cran_revdeps_versions(package, dependencies, bioc)$package
+cran_revdeps <- function(package, dependencies = TRUE, bioc = FALSE, cran = TRUE) {
+  pkgs <- cran_revdeps_versions(package, dependencies, bioc, cran)$package
   pkgs[order(tolower(pkgs))]
 }
 
 #' @importFrom remotes bioc_install_repos
 #' @importFrom crancache available_packages
 
-cran_revdeps_versions <- function(package, dependencies = TRUE, bioc = FALSE) {
+cran_revdeps_versions <- function(package, dependencies = TRUE, bioc = FALSE, cran = TRUE) {
   stopifnot(is_string(package))
-  repos <- get_repos(bioc)
+  repos <- get_repos(bioc, cran)
 
   allpkgs <- available_packages(repos = repos)
   alldeps <- allpkgs[, dependencies, drop = FALSE]
@@ -29,12 +29,13 @@ cran_revdeps_versions <- function(package, dependencies = TRUE, bioc = FALSE) {
   )
 }
 
-get_repos <- function(bioc) {
+get_repos <- function(bioc, cran) {
   repos <- c(
     getOption("repos"),
     if (bioc) bioc_install_repos()
   )
-  if (! "CRAN" %in% names(repos) || repos["CRAN"] == "@CRAN@") {
+  
+  if ((! "CRAN" %in% names(repos) || repos["CRAN"] == "@CRAN@") && cran) {
     repos["CRAN"] <- "https://cloud.r-project.org"
   }
 

--- a/R/deps.R
+++ b/R/deps.R
@@ -40,7 +40,10 @@ get_repos <- function(bioc, cran) {
   }
 
   ## Drop duplicated repos (by name only)
-  names <- names(repos)
+  ## If the repos is not a named vector, names would be a NULL
+  ## and duplicated(names) would be a logical(0) resulting in dropping entire 
+  ## vector
+  names <- names(repos) %|0|% rep("", times = length(repos))
   repos <- repos[!(nzchar(names) & duplicated(names))]
 
   repos

--- a/R/deps.R
+++ b/R/deps.R
@@ -20,7 +20,7 @@ cran_revdeps_versions <- function(package, dependencies = TRUE, bioc = FALSE, cr
   alldeps <- allpkgs[, dependencies, drop = FALSE]
   alldeps[is.na(alldeps)] <- ""
   deps <- apply(alldeps, 1, paste, collapse = ",")
-  rd <- grepl(paste0("\\b", package, "\\b"), deps)
+  rd <- grepl(sprintf("(,| |\\n)(%s)(,| |\\n)", package), deps)
 
   data.frame(
     stringsAsFactors = FALSE,

--- a/R/download.R
+++ b/R/download.R
@@ -1,4 +1,4 @@
-download_opts <- function(pkgdir, pkgname) {
+download_opts <- function(pkgdir, pkgname, bioc, cran) {
   dir <- dir_find(pkgdir, "check", pkgname)
 
   func <- function(pkgname, dir, repos) {
@@ -8,7 +8,7 @@ download_opts <- function(pkgdir, pkgname) {
 
   r_process_options(
     func = func,
-    args = list(pkgname = pkgname, dir = dir, repos = get_repos(bioc = TRUE, cran = TRUE)),
+    args = list(pkgname = pkgname, dir = dir, repos = get_repos(bioc = bioc, cran = cran)),
     system_profile = FALSE,
     user_profile = FALSE,
     env = c(CRANCACHE_REPOS = "cran,bioc", CRANCACHE_QUIET = "yes")
@@ -18,9 +18,11 @@ download_opts <- function(pkgdir, pkgname) {
 download_task <- function(state, task) {
   pkgdir <- state$options$pkgdir
   pkgname <- task$args[[1]]
-
+  bioc <- state$options$bioc
+  cran <- state$options$cran
+  
   "!DEBUG Downloading source of `pkgname`"
-  px_opts <- download_opts(pkgdir, pkgname)
+  px_opts <- download_opts(pkgdir, pkgname, bioc, cran)
   px <- r_process$new(px_opts)
 
   ## update state

--- a/R/download.R
+++ b/R/download.R
@@ -8,7 +8,7 @@ download_opts <- function(pkgdir, pkgname) {
 
   r_process_options(
     func = func,
-    args = list(pkgname = pkgname, dir = dir, repos = get_repos(bioc = TRUE)),
+    args = list(pkgname = pkgname, dir = dir, repos = get_repos(bioc = TRUE, cran = TRUE)),
     system_profile = FALSE,
     user_profile = FALSE,
     env = c(CRANCACHE_REPOS = "cran,bioc", CRANCACHE_QUIET = "yes")

--- a/R/report.R
+++ b/R/report.R
@@ -179,7 +179,7 @@ cat_package_info <- function(cmp, file) {
 }
 
 num_deps <- function(pkg) {
-  repos <- get_repos(bioc = TRUE)
+  repos <- get_repos(bioc = TRUE, cran = TRUE)
   length(cran_deps(pkg, repos))
 }
 

--- a/R/revdepcheck.R
+++ b/R/revdepcheck.R
@@ -78,8 +78,9 @@ revdep_check <- function(pkg = ".",
       install = revdep_install(pkg, quiet = quiet, env = env, 
                                bioc = bioc, cran = cran),
       run =     revdep_run(pkg, quiet = quiet, timeout = timeout,
-                           num_workers = num_workers, env = env),
-      report =  revdep_final_report(pkg),
+                           num_workers = num_workers, env = env,
+                           bioc = bioc, cran = cran),
+      report =  revdep_final_report(pkg, bioc = bioc, cran = cran),
       done =    break
     )
     did_something <- TRUE
@@ -185,7 +186,8 @@ revdep_install <- function(pkg = ".", quiet = FALSE, env = character(),
 
 revdep_run <- function(pkg = ".", quiet = TRUE,
                        timeout = as.difftime(10, units = "mins"),
-                       num_workers = 1, bioc = TRUE, env = character()) {
+                       num_workers = 1, bioc = TRUE, env = character(),
+                       cran = TRUE) {
 
   pkg <- pkg_check(pkg)
   pkgname <- pkg_name(pkg)
@@ -205,7 +207,9 @@ revdep_run <- function(pkg = ".", quiet = TRUE,
       quiet = quiet,
       timeout = timeout,
       num_workers = num_workers,
-      env = env),
+      env = env,
+      bioc = bioc,
+      cran = cran),
     packages = data.frame(
       package = todo,
       state = if (length(todo)) "todo" else character(),
@@ -224,10 +228,10 @@ revdep_run <- function(pkg = ".", quiet = TRUE,
   invisible()
 }
 
-revdep_final_report <- function(pkg = ".") {
+revdep_final_report <- function(pkg = ".", bioc = TRUE, cran = TRUE) {
   db_metadata_set(pkg, "todo", "done")
   status("REPORT")
-  revdep_report(pkg)
+  revdep_report(pkg, bioc = bioc, cran = cran)
 }
 
 report_exists <- function(pkg) {

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <!-- badges: start -->
 [![R-CMD-check](https://github.com/r-lib/revdepcheck/workflows/R-CMD-check/badge.svg)](https://github.com/r-lib/revdepcheck/actions)
-[![Codecov test coverage](https://codecov.io/gh/r-lib/revdepcheck/branch/master/graph/badge.svg)](https://codecov.io/gh/r-lib/revdepcheck?branch=master)
+[![Codecov test coverage](https://codecov.io/gh/r-lib/revdepcheck/branch/main/graph/badge.svg)](https://codecov.io/gh/r-lib/revdepcheck?branch=main)
 [![](http://www.r-pkg.org/badges/version/revdepcheck)](http://www.r-pkg.org/pkg/revdepcheck)
 [![CRAN RStudio mirror downloads](http://cranlogs.r-pkg.org/badges/revdepcheck)](http://www.r-pkg.org/pkg/revdepcheck)
 <!-- badges: end -->

--- a/man/cran_revdeps.Rd
+++ b/man/cran_revdeps.Rd
@@ -4,7 +4,7 @@
 \alias{cran_revdeps}
 \title{Retrieve the reverse dependencies for a package}
 \usage{
-cran_revdeps(package, dependencies = TRUE, bioc = FALSE)
+cran_revdeps(package, dependencies = TRUE, bioc = FALSE, cran = TRUE)
 }
 \arguments{
 \item{package}{The package to search for reverse dependencies}
@@ -13,6 +13,9 @@ cran_revdeps(package, dependencies = TRUE, bioc = FALSE)
 release, we recommend using the default.}
 
 \item{bioc}{Also check revdeps that live in Bioconductor?}
+
+\item{cran}{Should cran mirror be attached to getOpion("repos") if it
+is not already present.}
 }
 \description{
 Retrieve the reverse dependencies for a package

--- a/man/revdep_check.Rd
+++ b/man/revdep_check.Rd
@@ -12,6 +12,7 @@ revdep_check(
   timeout = as.difftime(10, units = "mins"),
   num_workers = 1,
   bioc = TRUE,
+  cran = TRUE,
   env = revdep_env_vars()
 )
 
@@ -31,6 +32,9 @@ complete. Default is 10 minutes.}
 \item{num_workers}{Number of parallel workers to use}
 
 \item{bioc}{Also check revdeps that live in Bioconductor?}
+
+\item{cran}{Should cran mirror be attached to getOpion("repos") if it
+is not already present.}
 
 \item{env}{Environment variables to set for the install and check
 processes. See \code{\link[=revdep_env_vars]{revdep_env_vars()}}.}

--- a/man/revdep_check.Rd
+++ b/man/revdep_check.Rd
@@ -46,6 +46,8 @@ released version on CRAN and once for the local development version. It
 then reports the differences so you can see what checks were previously
 ok but now fail.
 
+It requires to use a repos option that provides the source code of the packages not binaries.
+
 Once your package has been successfully submitted to CRAN, you should
 run \code{revdep_reset()}. This deletes all files used for checking, freeing
 up disk space and leaving you in a clean state for the next release.

--- a/man/revdep_report_summary.Rd
+++ b/man/revdep_report_summary.Rd
@@ -10,13 +10,26 @@
 \usage{
 revdep_report_summary(pkg = ".", file = "", all = FALSE, results = NULL)
 
-revdep_report_problems(pkg = ".", file = "", all = FALSE, results = NULL)
+revdep_report_problems(
+  pkg = ".",
+  file = "",
+  all = FALSE,
+  results = NULL,
+  bioc = TRUE,
+  cran = TRUE
+)
 
-revdep_report_failures(pkg = ".", file = "", results = NULL)
+revdep_report_failures(
+  pkg = ".",
+  file = "",
+  results = NULL,
+  bioc = TRUE,
+  cran = TRUE
+)
 
 revdep_report_cran(pkg = ".", file = "", results = NULL)
 
-revdep_report(pkg = ".", all = FALSE, results = NULL)
+revdep_report(pkg = ".", all = FALSE, results = NULL, bioc = TRUE, cran = TRUE)
 }
 \arguments{
 \item{pkg}{Path to package.}
@@ -30,6 +43,11 @@ omitted by default, and only problems seen with the new version of
 the package are reported.}
 
 \item{results}{Cached results from \code{db_results()}. Expert use only.}
+
+\item{bioc}{Also check revdeps that live in Bioconductor?}
+
+\item{cran}{Should cran mirror be attached to getOpion("repos") if it
+is not already present.}
 }
 \description{
 You can use these functions to get intermediate reports of a \code{\link[=revdep_check]{revdep_check()}}


### PR DESCRIPTION
@gaborcsardi  This is a candidate fix for #333

I've realized that fixing the issue reported above is dead simple. In my opinion `get_repos()` helper should append CRAN to repos only conditionally on some input parameter, rather than every time CRAN is not found in current options. Therefore I've just added this parameter and propagated it upstream including `revdep_check()` and documentation.