### PR TITLE
Consider \\. to be part of package name.

### DIFF
--- a/R/deps.R
+++ b/R/deps.R
@@ -20,7 +20,7 @@ cran_revdeps_versions <- function(package, dependencies = TRUE, bioc = FALSE) {
   alldeps <- allpkgs[, dependencies, drop = FALSE]
   alldeps[is.na(alldeps)] <- ""
   deps <- apply(alldeps, 1, paste, collapse = ",")
-  rd <- grepl(paste0("\\b", package, "\\b"), deps)
+  rd <- grepl(paste0("\\b(?<!\\.)", package, "(?!\\.)\\b"), deps, perl = TRUE)
 
   data.frame(
     stringsAsFactors = FALSE,


### PR DESCRIPTION
Previously dependencies of leaflet.extras were being included (extras only has 4 depedencies)
``` r
revdepcheck::cran_revdeps("extras", "Imports")
#>  [1] "animaltracker" "bcdata"        "GPSeqClus"     "gwavr"        
#>  [5] "IceSat2R"      "mapedit"       "mcmcderive"    "mcmcr"        
#>  [9] "MDMAPR"        "naturaList"    "nlist"         "oceanis"      
#> [13] "term"          "wallace"
```

<sup>Created on 2022-10-29 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Now with this pull request the correct 4 dependencies are returned
``` r
revdepcheck::cran_revdeps("extras", "Imports")
#> [1] "mcmcderive" "mcmcr"      "nlist"      "term"
```

<sup>Created on 2022-10-29 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>