### PR TITLE
Accept multiple package names in cran_revdeps()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,4 +59,4 @@ Remotes:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # 1.0.0.9000
 
+* `cloud_check()` gains the ability to add additional packages as the source
+  of reverse dependencies.
+
 * `cran_revdeps()` now accepts multiple packge names.
 
 * `cloud_results()` gains a progress bar so you can see what's happening

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # 1.0.0.9000
 
+* `cran_revdeps()` now accepts multiple packge names.
+
 * `cloud_results()` gains a progress bar so you can see what's happening
   for large revdep runs (#273)
   

--- a/R/cloud.R
+++ b/R/cloud.R
@@ -141,6 +141,8 @@ cloud_fetch_results <- function(job_name = cloud_job(pkg = pkg), pkg = ".") {
 #'   equal to [cran_revdeps()]
 #' @param r_version The R version to use.
 #' @param check_args Additional argument to pass to `R CMD check`
+#' @param extra_revdeps Additional packages to use as source for reverse
+#'   dependencies.
 #' @returns The AWS Batch job name
 #' @inheritParams revdep_check
 #' @importFrom cli cli_alert_info cli_alert_success cli_alert_danger
@@ -150,6 +152,7 @@ cloud_fetch_results <- function(job_name = cloud_job(pkg = pkg), pkg = ".") {
 cloud_check <- function(pkg = ".",
   tarball = NULL,
   revdep_packages = NULL,
+  extra_revdeps = NULL,
   r_version = "4.1.1",
   check_args = "--no-manual") {
   if (is.null(tarball)) {
@@ -164,7 +167,10 @@ cloud_check <- function(pkg = ".",
   # Lookup revdeps with R, as the RSPM db seems not quite right, for instance
   # it seems to include archived packages.
   if (is.null(revdep_packages)) {
-    revdep_packages <- setdiff(cran_revdeps(package_name), package_name)
+    revdep_packages <- setdiff(
+      cran_revdeps(c(package_name, extra_revdeps)),
+      package_name
+    )
   }
 
   if (length(revdep_packages) == 1) {

--- a/R/deps.R
+++ b/R/deps.R
@@ -1,11 +1,12 @@
 
 #' Retrieve the reverse dependencies for a package
 #'
-#' @param package The package to search for reverse dependencies
+#' @param package The package (or packages) to search for reverse dependencies.
 #' @inheritParams revdep_check
 #' @export
 cran_revdeps <- function(package, dependencies = TRUE, bioc = FALSE) {
-  pkgs <- cran_revdeps_versions(package, dependencies, bioc)$package
+  pkgs <- lapply(package, function(pkg) cran_revdeps_versions(pkg, dependencies, bioc)$package)
+  pkgs <- unique(unlist(pkgs))
   pkgs[order(tolower(pkgs))]
 }
 

--- a/man/cloud_check.Rd
+++ b/man/cloud_check.Rd
@@ -8,6 +8,7 @@ cloud_check(
   pkg = ".",
   tarball = NULL,
   revdep_packages = NULL,
+  extra_revdeps = NULL,
   r_version = "4.1.1",
   check_args = "--no-manual"
 )
@@ -20,6 +21,9 @@ automatically built for the package at \code{pkg} by \code{\link[pkgbuild:build]
 
 \item{revdep_packages}{A character vector of packages to check, if \code{NULL}
 equal to \code{\link[=cran_revdeps]{cran_revdeps()}}}
+
+\item{extra_revdeps}{Additional packages to use as source for reverse
+dependencies.}
 
 \item{r_version}{The R version to use.}
 

--- a/man/cran_revdeps.Rd
+++ b/man/cran_revdeps.Rd
@@ -7,7 +7,7 @@
 cran_revdeps(package, dependencies = TRUE, bioc = FALSE)
 }
 \arguments{
-\item{package}{The package to search for reverse dependencies}
+\item{package}{The package (or packages) to search for reverse dependencies.}
 
 \item{dependencies}{Which types of revdeps should be checked. For CRAN
 release, we recommend using the default.}


### PR DESCRIPTION
This is useful for packages like waldo where you also want to test reverse dependencies of a reverse dependency (i.e. testthat)