### PR TITLE
Bump R version for cloud checks

### DIFF
--- a/R/cloud.R
+++ b/R/cloud.R
@@ -153,7 +153,7 @@ cloud_check <- function(pkg = ".",
   tarball = NULL,
   revdep_packages = NULL,
   extra_revdeps = NULL,
-  r_version = "4.2.1",
+  r_version = "4.3.0",
   check_args = "--no-manual") {
   if (is.null(tarball)) {
     cli::cli_alert_info("Building package tarball")


### PR DESCRIPTION
Presumably needs to wait until the back end supports this (https://github.com/rstudio/revdepcheck-cloud/issues/121)