### PR TITLE
Default `bioc` back to `FALSE` for `cloud_check()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,9 @@
 * `cloud_check(r_version = "4.3.1")` is the updated default (#361).
 
 * `cloud_check()` gains the ability to check Bioconductor packages via a new
-  `bioc` argument, with default `TRUE` (#362)
+  `bioc` argument, with a default of `FALSE` do to a relatively high likelihood
+  of failed checks since Bioconductor system dependencies are currently not
+  installed in the cloud check service (#362, #369).
 
 * updated pkgdown template and url to https://revdepcheck.r-lib.org.
 
@@ -14,7 +16,7 @@
 
 * `cloud_results()` gains a progress bar so you can see what's happening
   for large revdep runs (#273)
-  
+
 * `cloud_report()` can opt-out of saving failures, and saves the CRAN report
   the same way as `revdep_report()` (#271).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 * `cloud_check(r_version = "4.3.1")` is the updated default (#361).
 
 * `cloud_check()` gains the ability to check Bioconductor packages via a new
-  `bioc` argument, with a default of `FALSE` do to a relatively high likelihood
+  `bioc` argument, with a default of `FALSE` due to a relatively high likelihood
   of failed checks since Bioconductor system dependencies are currently not
   installed in the cloud check service (#362, #369).
 

--- a/R/cloud.R
+++ b/R/cloud.R
@@ -143,7 +143,7 @@ cloud_fetch_results <- function(job_name = cloud_job(pkg = pkg), pkg = ".") {
 #' @param check_args Additional argument to pass to `R CMD check`
 #' @param extra_revdeps Additional packages to use as source for reverse
 #'   dependencies.
-#' @param bioc Also check revdeps that live in Bioconductor? Default `TRUE`.
+#' @param bioc Also check revdeps that live in Bioconductor? Default `FALSE`.
 #'   Note that the cloud revdep check service does not currently include system
 #'   dependencies of Bioconductor packages, so there is potential for more
 #'   failed checks.
@@ -159,7 +159,7 @@ cloud_check <- function(pkg = ".",
   extra_revdeps = NULL,
   r_version = "4.3.1",
   check_args = "--no-manual",
-  bioc = TRUE) {
+  bioc = FALSE) {
   if (is.null(tarball)) {
     cli::cli_alert_info("Building package tarball")
     pkg <- pkg_check(pkg)

--- a/man/cloud_check.Rd
+++ b/man/cloud_check.Rd
@@ -11,7 +11,7 @@ cloud_check(
   extra_revdeps = NULL,
   r_version = "4.3.1",
   check_args = "--no-manual",
-  bioc = TRUE
+  bioc = FALSE
 )
 }
 \arguments{
@@ -30,7 +30,7 @@ dependencies.}
 
 \item{check_args}{Additional argument to pass to \verb{R CMD check}}
 
-\item{bioc}{Also check revdeps that live in Bioconductor? Default \code{TRUE}.
+\item{bioc}{Also check revdeps that live in Bioconductor? Default \code{FALSE}.
 Note that the cloud revdep check service does not currently include system
 dependencies of Bioconductor packages, so there is potential for more
 failed checks.}


### PR DESCRIPTION
Alters part of https://github.com/r-lib/revdepcheck/pull/363

As discussed on slack, since we get a very high amount of failures in dplyr since Bioc system deps aren't installed, we would rather this default to `FALSE` for the cloud checks.