### PR TITLE
Minor tweaks

### DIFF
--- a/R/report.R
+++ b/R/report.R
@@ -56,7 +56,7 @@ revdep_report_summary <- function(pkg = ".", file = "", all = FALSE, results = N
 }
 
 revdep_report_section <- function(title, rows, file) {
-  if (nrow(rows) == 0) {
+  if (NROW(rows) == 0) {
     return()
   }
 
@@ -226,7 +226,7 @@ normalize_space <- function(x) {
 }
 
 cat_failure_section <- function(title, rows, file) {
-  if (nrow(rows) == 0) {
+if (NROW(rows) == 0) {
     return()
   }
 

--- a/R/revdepcheck.R
+++ b/R/revdepcheck.R
@@ -7,6 +7,8 @@
 #' then reports the differences so you can see what checks were previously
 #' ok but now fail.
 #'
+#' It requires to use a repos option that provides the source code of the packages not binaries.
+#'
 #' Once your package has been successfully submitted to CRAN, you should
 #' run `revdep_reset()`. This deletes all files used for checking, freeing
 #' up disk space and leaving you in a clean state for the next release.


### PR DESCRIPTION
This commit fixes a problem that some [users experiment](https://github.com/r-lib/revdepcheck/issues/99#issuecomment-631487721), I don't know the root cause of this but it seems in some cases rows is NULL resulting in an error when `nrow(NULL)` but not with `NROW(NULL)`.

It documents a bit that the `getOptions("repos")` should provide source code not binaries (from a comment in the rOpenSci slack) but this is more or less stated as important in some [comments here](https://github.com/r-lib/revdepcheck/issues/342).