### PR TITLE
fix error when debugme is on

### DIFF
--- a/R/event-loop.R
+++ b/R/event-loop.R
@@ -166,7 +166,7 @@ handle_event <- function(state, which) {
       state$workers[[which]]$stderr <-
         c(state$workers[[which]]$stderr, err <- proc$read_error(n = 10000))
     } else {
-      state$workers[[which]]$stderr <- ""
+      state$workers[[which]]$stderr <- err <- ""
     }
   } else {
     state$workers[[which]]$stdout <-
@@ -175,7 +175,7 @@ handle_event <- function(state, which) {
       state$workers[[which]]$stderr <-
         c(state$workers[[which]]$stderr, err <- proc$read_all_error())
     } else {
-      state$workers[[which]]$stderr <- ""
+      state$workers[[which]]$stderr <- err <- ""
     }
   }
 


### PR DESCRIPTION
Fix the following error (extract from logs). Note that you have to have debugme switched on.
```
revdepcheck +-handle event, package chevron +59ms 
Error in handle_event(state, i) : object 'err' not found
Calls: <Anonymous> ... <Anonymous> -> get_debug_levels -> regexpr -> is.factor -> paste0
revdepcheck +-remove 4 workers +2ms 
Execution halted
```