### PR TITLE
Update default R version to 4.4.0 on cloud check

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 * Add `cran` parameter to the `get_repos()` internal and propagate it to the
   upstream functions including `revdep_check()`. It allow user to decide
   whether htey want to always append CRAN mirror to repos or not (@maksymis)
+  
+* `cloud_check(r_version = "4.4.0")` is the updated default.
 
 # revdepcheck (development version)
 

--- a/R/cloud.R
+++ b/R/cloud.R
@@ -157,7 +157,7 @@ cloud_check <- function(pkg = ".",
   tarball = NULL,
   revdep_packages = NULL,
   extra_revdeps = NULL,
-  r_version = "4.3.1",
+  r_version = "4.4.0",
   check_args = "--no-manual",
   bioc = FALSE) {
   if (is.null(tarball)) {


### PR DESCRIPTION
This updates R following https://github.com/rstudio/revdepcheck-cloud/pull/135