### PR TITLE
terminal newline for problem-free report

### DIFF
--- a/R/report.R
+++ b/R/report.R
@@ -114,7 +114,7 @@ revdep_report_if <- function(pkg = ".", file = "", predicate, results = NULL,
   if (sum(show)) {
     map(results[show], failure_details, file = file, bioc = bioc, cran = cran)
   } else {
-    cat("*Wow, no problems at all. :)*", file = file)
+    cat("*Wow, no problems at all. :)*\n", file = file)
   }
 
   invisible()


### PR DESCRIPTION
Encountered this when `cat` failed to return my cursor to the leftmost position. Mild annoyance :)

I glanced at the other `cat()` usages here, they might be affected, but it will require a closer look from someone with more context, so I leave it as is for now.