### PR TITLE
Update default cloud R to 4.5.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: revdepcheck
 Title: Automated Reverse Dependency Checking
-Version: 1.0.0.9002
+Version: 1.0.0.9003
 Authors@R: c(
     person("Gábor", "Csárdi", , "csardi.gabor@gmail.com", c("cre", "aut", "cph")),
     person("Hadley", "Wickham", role = "aut"),
@@ -61,4 +61,4 @@ Config/Needs/website: tidyverse/tidytemplate
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 1.0.0.9003
+
+- * `cloud_check(r_version = "4.5.1")` is the updated default.
+
 # 1.0.0.9002
 
 * Add `cran` parameter to the `get_repos()` internal and propagate it to the

--- a/R/cloud.R
+++ b/R/cloud.R
@@ -157,7 +157,7 @@ cloud_check <- function(pkg = ".",
   tarball = NULL,
   revdep_packages = NULL,
   extra_revdeps = NULL,
-  r_version = "4.4.0",
+  r_version = "4.5.1",
   check_args = "--no-manual",
   bioc = FALSE) {
   if (is.null(tarball)) {

--- a/man/cloud_check.Rd
+++ b/man/cloud_check.Rd
@@ -9,7 +9,7 @@ cloud_check(
   tarball = NULL,
   revdep_packages = NULL,
   extra_revdeps = NULL,
-  r_version = "4.4.0",
+  r_version = "4.5.1",
   check_args = "--no-manual",
   bioc = FALSE
 )


### PR DESCRIPTION
Follow up on cloud update
- https://github.com/rstudio/revdepcheck-cloud/pull/146
