### PR TITLE
Add R 4.1.0 requirement for '\()'

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,7 @@ License: MIT + file LICENSE
 URL: https://revdepcheck.r-lib.org,
     https://github.com/r-lib/revdepcheck#readme
 BugReports: https://github.com/r-lib/revdepcheck/issues
+Depends: R (>= 4.1.0)
 Imports: 
     assertthat,
     brio,


### PR DESCRIPTION
`R CMD check` flags this:

https://github.com/r-lib/revdepcheck/blob/b6eb2668650581e818681d5e0d98f8fc666a03ae/R/report-checklist.R#L2