### PR TITLE
Default to current release (4.6.0) for cloud checks

### DIFF
--- a/R/cloud.R
+++ b/R/cloud.R
@@ -204,7 +204,7 @@ cloud_check <- function(
   tarball = NULL,
   revdep_packages = NULL,
   extra_revdeps = NULL,
-  r_version = "4.5.1",
+  r_version = "4.6.0",
   check_args = "--no-manual",
   bioc = FALSE
 ) {

--- a/man/cloud_check.Rd
+++ b/man/cloud_check.Rd
@@ -9,7 +9,7 @@ cloud_check(
   tarball = NULL,
   revdep_packages = NULL,
   extra_revdeps = NULL,
-  r_version = "4.5.1",
+  r_version = "4.6.0",
   check_args = "--no-manual",
   bioc = FALSE
 )


### PR DESCRIPTION
The other necessary change has already happened: https://github.com/rstudio/revdepcheck-cloud/pull/223.